### PR TITLE
Support Disabled Outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
 output "hostname" {
-  value = "${aws_route53_record.default.fqdn}"
+  value = "${join("", aws_route53_record.default.*.fqdn)}"
 }


### PR DESCRIPTION
## what
* Use `join` + `splat` pattern for outputs which can be disabled

## why
* Cannot reference resources that have been disabled with `count=0`