### PR TITLE
Upgrade to TF 0.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,14 @@ SHELL := /bin/bash
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md
+export TERRAFORM_VERSION ?= 0.12.1
 
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+## Override the terraform/validate from build-harness
+## so that it is TF 0.12 friendly.
+terraform/validate:
+	AWS_DEFAULT_REGION=us-east-1 @$(TERRAFORM) validate
 
 ## Lint terraform code
 lint:

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,18 @@ SHELL := /bin/bash
 
 # List of targets the `readme` target should call before generating the readme
 export README_DEPS ?= docs/targets.md docs/terraform.md
+
+# Specify to use TF 0.12 and export the default AWS region so that
+# terraform validate can run properly.
 export TERRAFORM_VERSION ?= 0.12.1
+export AWS_DEFAULT_REGION ?= us-east-1
 
 -include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
 
 ## Override the terraform/validate from build-harness
 ## so that it is TF 0.12 friendly.
 terraform/validate:
-	AWS_DEFAULT_REGION=us-east-1 @$(TERRAFORM) validate
+	@$(TERRAFORM) validate
 
 ## Lint terraform code
 lint:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
+| enabled | Set to false to prevent the module from creating any resources | bool | true | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | `dns` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | records | Records | list | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| enabled | Set to false to prevent the module from creating any resources | string | `true` | no |
+| enabled | Set to false to prevent the module from creating any resources | bool | true | no |
 | name | The Name of the application or solution  (e.g. `bastion` or `portal`) | string | `dns` | no |
 | namespace | Namespace (e.g. `cp` or `cloudposse`) | string | - | yes |
 | records | Records | list | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,9 @@
 resource "aws_route53_record" "default" {
-  count   = "${var.enabled == "true" ? 1 : 0}"
-  zone_id = "${var.zone_id}"
-  name    = "${var.name}"
-  type    = "${var.type}"
-  ttl     = "${var.ttl}"
-  records = ["${var.records}"]
+  count   = var.enabled == "true" ? 1 : 0
+  zone_id = var.zone_id
+  name    = var.name
+  type    = var.type
+  ttl     = var.ttl
+  records = var.records
 }
+

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "default" {
-  count   = var.enabled == true ? 1 : 0
+  count   = var.enabled ? 1 : 0
   zone_id = var.zone_id
   name    = var.name
   type    = var.type

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "default" {
-  count   = var.enabled == "true" ? 1 : 0
+  count   = var.enabled == true ? 1 : 0
   zone_id = var.zone_id
   name    = var.name
   type    = var.type

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "hostname" {
-  value       = "${join("", aws_route53_record.default.*.fqdn)}"
+  value       = join("", aws_route53_record.default.*.fqdn)
   description = "DNS hostname"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "zone_id" {
 }
 
 variable "records" {
-  type        = "list"
+  type        = list(string)
   description = "Records"
 }
 
@@ -35,3 +35,4 @@ variable "ttl" {
   default     = "300"
   description = "The TTL of the record to add to the DNS zone to complete certificate validation"
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,22 +1,27 @@
 variable "enabled" {
+  type        = bool
   description = "Set to false to prevent the module from creating any resources"
-  default     = "true"
+  default     = true
 }
 
 variable "namespace" {
+  type        = string
   description = "Namespace (e.g. `cp` or `cloudposse`)"
 }
 
 variable "stage" {
+  type        = string
   description = "Stage (e.g. `prod`, `dev`, `staging`)"
 }
 
 variable "name" {
+  type        = string
   description = "The Name of the application or solution  (e.g. `bastion` or `portal`)"
   default     = "dns"
 }
 
 variable "zone_id" {
+  type        = string
   default     = ""
   description = "Route53 DNS Zone id"
 }
@@ -27,11 +32,13 @@ variable "records" {
 }
 
 variable "type" {
+  type        = string
   default     = "CNAME"
   description = "Type"
 }
 
 variable "ttl" {
+  type        = string
   default     = "300"
   description = "The TTL of the record to add to the DNS zone to complete certificate validation"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12.0"
 }


### PR DESCRIPTION
Continue on from https://github.com/cloudposse/terraform-aws-route53-cluster-hostname/pull/13 by creating a TF 0.12 upgrade including some work to get the build passing correctly by modifying the makefile to use the right TF version and some "hacks" to ensure validate runs properly.