### PR TITLE
main_clone step fix for git name

### DIFF
--- a/codefresh/test.yml
+++ b/codefresh/test.yml
@@ -8,67 +8,72 @@ steps:
   wait:
     title: Wait
     stage: Prepare
-    image: codefresh/cli:latest
+    image: 'codefresh/cli:latest'
     commands:
-      - codefresh get builds --pipeline=${{CF_REPO_NAME}} --status running --limit 1000 -o json | jq --arg id ${{CF_BUILD_ID}} -ser 'flatten|.[-1].id==$id'
+      - >-
+        codefresh get builds --pipeline=${{CF_REPO_NAME}} --status running
+        --limit 1000 -o json | jq --arg id ${{CF_BUILD_ID}} -ser
+        'flatten|.[-1].id==$id'
     retry:
       maxAttempts: 10
       delay: 20
       exponentialFactor: 1.1
 
   main_clone:
-    title: "Clone repository"
+    title: Clone repository
     type: git-clone
     stage: Prepare
-    description: "Initialize"
-    repo: ${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}
-    git: CF-default
-    revision: ${{CF_REVISION}}
+    description: Initialize
+    repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
+    git: github
+    revision: '${{CF_REVISION}}'
 
   clean_init:
     title: Prepare build-harness and test-harness
-    image: ${{TEST_IMAGE}}
+    image: '${{TEST_IMAGE}}'
     stage: Prepare
     commands:
-      - cf_export PATH="/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      - >-
+        cf_export
+        PATH="/usr/local/terraform/0.12/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
       - make init
       - git -C build-harness checkout master
       - make -C test/ clean init TEST_HARNESS_BRANCH=master
       - make -C test/src clean init
       - find . -type d -name '.terraform' | xargs rm -rf
-      - find . -type f -name 'terraform.tfstate*' -exec rm -f {} \;
+      - 'find . -type f -name ''terraform.tfstate*'' -exec rm -f {} \;'
 
   test:
-    type: "parallel"
-    title: "Run tests"
-    description: "Run all tests in parallel"
+    type: parallel
+    title: Run tests
+    description: Run all tests in parallel
     stage: Test
     steps:
       test_readme_lint:
-        title: "Test README.md updated"
-        stage: "Test"
-        image: ${{TEST_IMAGE}}
+        title: Test README.md updated
+        stage: Test
+        image: '${{TEST_IMAGE}}'
         description: Test "readme/lint"
         commands:
           - make readme/lint
 
       test_module:
         title: Test module with bats
-        image: ${{TEST_IMAGE}}
+        image: '${{TEST_IMAGE}}'
         stage: Test
         commands:
           - make -C test/ module
 
       test_examples_complete:
         title: Test "examples/complete" with bats
-        image: ${{TEST_IMAGE}}
+        image: '${{TEST_IMAGE}}'
         stage: Test
         commands:
           - make -C test/ examples/complete
 
       test_examples_complete_terratest:
         title: Test "examples/complete" with terratest
-        image: ${{TEST_IMAGE}}
+        image: '${{TEST_IMAGE}}'
         stage: Test
         commands:
           - make -C test/src


### PR DESCRIPTION
## what
* main_clone step fix for git name

## why
* pipeline fails due to issue with wrong `git` parameter
