### PR TITLE
use minimum versions for provider pinning

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws   = "~> 2.0"
-    local = "~> 1.2"
+    aws   = ">= 2.0"
+    local = ">= 1.2"
   }
 }


### PR DESCRIPTION
## what
set minimum versions for providers without pinning to a specific major version



## why
the current method makes it very difficult to maintain or upgrade consistent provider versions within a project



## references
https://www.terraform.io/docs/configuration/provider-requirements.html#best-practices-for-provider-versions



