### PR TITLE
Bump AWS provider 3.0

### DIFF
--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -6,9 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 3.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.2"
-    }
   }
 }


### PR DESCRIPTION
## what
* Bump AWS provider 3.0

## why
* Downstream modules can take advantage of the more recent aws provider

## references
N/A

