### PR TITLE
feat: add route53 healthchecks

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -6,6 +6,6 @@ name = "test-hostname"
 
 type = "CNAME"
 
-zone_id = "Z3SO0TKDDQ0RGG"
+zone_id = "Z0880904EUMUUAAGCA17"
 
 records = ["test-hostname"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -8,6 +8,9 @@ module "hostname" {
   zone_id = var.zone_id
   type    = var.type
   records = var.records
+  ttl     = var.ttl
+
+  healthcheck_enabled = var.healthcheck_enabled
 
   context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -21,3 +21,10 @@ variable "ttl" {
   default     = 300
   description = "The TTL of the record to add to the DNS zone to complete certificate validation"
 }
+
+variable "healthcheck_enabled" {
+  type        = bool
+  description = "Whether to create a Route53 health check"
+  default     = false
+}
+

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,13 +1,16 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS region"
 }
 
 variable "zone_id" {
-  type = string
+  type        = string
+  description = "Route53 DNS Zone ID"
 }
 
 variable "records" {
-  type = list(string)
+  description = "DNS records to create"
+  type        = list(string)
 }
 
 variable "type" {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -30,7 +30,7 @@ resource "aws_route53_health_check" "default" {
   port       = var.healthcheck_settings.port
   regions    = var.healthcheck_settings.regions
 
-  resource_name   = var.healthcheck_settings.resource_name
+  reference_name  = var.healthcheck_settings.reference_name
   resource_path   = var.healthcheck_settings.resource_path
   search_string   = var.healthcheck_settings.search_string
   measure_latency = var.healthcheck_settings.measure_latency

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 data "aws_route53_zone" "default" {
-  count = module.this.enabled ? 1 : 0
+  count = local.enabled ? 1 : 0
 
   name         = var.zone_name
   private_zone = var.private_zone
@@ -13,10 +13,38 @@ data "aws_route53_zone" "default" {
 }
 
 resource "aws_route53_record" "default" {
-  count   = module.this.enabled ? 1 : 0
+  count   = local.enabled ? 1 : 0
   name    = var.dns_name == "" ? module.this.id : var.dns_name
   zone_id = join("", data.aws_route53_zone.default[*].zone_id)
   type    = var.type
   ttl     = var.ttl
   records = var.records
+}
+
+resource "aws_route53_health_check" "default" {
+  count = local.enabled && var.healthcheck_enabled ? 1 : 0
+
+  fqdn       = coalesce(var.healthcheck_settings.domain, aws_route53_record.default[0].fqdn)
+  ip_address = var.healthcheck_settings.ip_address
+  type       = var.healthcheck_settings.type
+  port       = var.healthcheck_settings.port
+  regions    = var.healthcheck_settings.regions
+
+  resource_name   = var.healthcheck_settings.resource_name
+  resource_path   = var.healthcheck_settings.resource_path
+  search_string   = var.healthcheck_settings.search_string
+  measure_latency = var.healthcheck_settings.measure_latency
+
+  routing_control_arn = var.type == "RECOVERY_CONTROL" ? var.healthcheck_settings.routing_control_arn : null
+  enable_sni          = var.type == "HTTPS" ? true : false
+
+  # Must be either 10 or 30
+  request_interval = var.healthcheck_settings.request_interval
+  # Must be between 0 and 256
+  child_health_threshold = var.healthcheck_settings.child_health_threshold
+  child_healthchecks     = var.healthcheck_settings.child_healthchecks
+  invert_healthcheck     = var.healthcheck_settings.invert_healthcheck
+  failure_threshold      = var.healthcheck_settings.failure_threshold
+  # Valid values are Healthy , Unhealthy and LastKnownStatus
+  insufficient_data_health_status = var.healthcheck_settings.insufficient_data_health_status
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "hostname" {
-  value       = join("", aws_route53_record.default.*.fqdn)
+  value       = join("", aws_route53_record.default[*].fqdn)
   description = "DNS hostname"
 }

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -38,7 +38,7 @@ func TestExamplesComplete(t *testing.T) {
 
 	// Run `terraform output` to get the value of an output variable
 	hostname := terraform.Output(t, terraformOptions, "hostname")
-	expectedHostname := "test-hostname-" + randId + ".testing.cloudposse.co"
+	expectedHostname := "test-hostname-" + randId + ".modules.cptest.test-automation.app"
 	// Verify we're getting back the outputs we expect
 	assert.Equal(t, expectedHostname, hostname)
 }

--- a/variables.tf
+++ b/variables.tf
@@ -50,3 +50,56 @@ variable "dns_name" {
   description = "The name of the DNS record"
   default     = ""
 }
+
+variable "healthcheck_enabled" {
+  type        = bool
+  description = "Whether to create a Route53 health check"
+  default     = false
+}
+
+variable "healthcheck_settings" {
+  type = object({
+    domain                          = optional(string)
+    ip_address                      = optional(string)
+    regions                         = optional(list(string))
+    type                            = optional(string, "HTTPS")
+    request_interval                = optional(string, "30")
+    port                            = optional(number, 443)
+    reference_name                  = optional(string)
+    resource_path                   = optional(string)
+    failure_threshold               = optional(number)
+    search_string                   = optional(string)
+    measure_latency                 = optional(bool)
+    invert_healthcheck              = optional(bool)
+    child_healthchecks              = optional(list(string))
+    routing_control_arn             = optional(string)
+    child_health_threshold          = optional(number)
+    cloudwatch_alarm_name           = optional(string)
+    cloudwatch_alarm_region         = optional(string)
+    insufficient_data_health_status = optional(string)
+  })
+  description = <<EOT
+  Route 53 health check configuration settings
+
+  domain: The fully qualified domain name of the endpoint to be checked
+  ip_address: The IP address of the endpoint to be checked
+  regions: AWS regions to run the health checks from
+  type: The protocol to use for the health check such as HTTP HTTPS TCP etc
+  port: Port on the endpoint to be checked
+  reference_name: Used in caller reference and helpful for identifying individual health check sets
+  resource_path: The URL path Route 53 requests during the health check
+  failure_threshold: Number of consecutive health checks that an endpoint must pass or fail
+  search_string: String searched in response body for match checks
+  measure_latency: Whether to measure and report latency from multiple regions
+  invert_healthcheck: If true a healthy check is considered unhealthy and vice versa
+  child_healthchecks: List of health check IDs for associated child checks
+  routing_control_arn: ARN of the Application Recovery Controller routing control
+  request_interval: Interval between health check requests in seconds
+  child_health_threshold: Minimum number of child checks that must be healthy
+  cloudwatch_alarm_name: Name of the CloudWatch alarm to evaluate
+  cloudwatch_alarm_region: Region where the CloudWatch alarm is configured
+  insufficient_data_health_status: Status to assign when CloudWatch has insufficient data
+  EOT
+  default     = {}
+  nullable    = false
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.9"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## what

> [!IMPORTANT]
> Feel free to adopt, disregard, or close this PR

- Create an optional resource for creating Route 53 health checks

## why

- Enables automated health monitoring of endpoints directly within infrastructure deployments
- Supports a wide range of use cases including latency tracking, string match validation, and multi-region health validation
- Aligns with existing AWS failover and recovery patterns
- Provides fine-grained control through configurable parameters without enforcing strict coupling to any particular deployment pattern
- Helps improve system reliability and observability by integrating with CloudWatch and Route 53 features

## references

- https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/dns-failover.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_health_check